### PR TITLE
BDT Classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The primary goal is to make these anomaly detection methods more accessible and 
 - `demos/cathode_walkthrough.ipynb` simply describes the basic working principle of the CATHODE method for weakly supervised anomaly detection on the LHCO example dataset.
 - `demos/lacathode_walkthrough.ipynb` touches the issue of background sculpting and guides through the working principle of LaCATHODE to mitigate this in (CATHODE-based) weak supervision.
 - `demos/anode_walkthrough.ipynb` gives a brief overview of the ANODE method (CATHODE's predecessor) for anomaly detection, which works analogous to weak supervision but constructs an explicit likelihood ratio using normalizing flows instead of training a classifier.
+- `demos/tree_classifier.ipynb` discusses the challenge of uninformative features in weakly supervised anomaly detection and demonstrates substantial improvement by using ensembles of boosted decision trees instead of neural networks.
 
 ## Installation
 

--- a/demos/tree_classifier.ipynb
+++ b/demos/tree_classifier.ipynb
@@ -1,0 +1,712 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Weak Supervision With Trees"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the notebook `demos/weak_supervision.ipynb` we have seen that a neural network (NN) classifier trained to distinguish a signal+background sample from a background-only one will also learn to distinguish signal from background directly. We call this (unrealistic) case where we have a perfect background-only dataset an *idealized anomaly detector* (IAD), as it is an idealization of anomaly detection approaches, such as [CWoLa Hunting](https://arxiv.org/abs/1902.02634) and [CATHODE](https://arxiv.org/abs/2109.00546) where we obtain this background sample in a data-driven way. I.e. any challenges that we face with an IAD will very likely apply to weakly supervised anomaly detection methods in general.\n",
+    "\n",
+    "We will explore one such challenge in this notebook: the **sensitivity loss due to uninformative features**. In order to be sensitive to a broad range of anomalies (thus being maximally model agnostic), we would ideally add as many input features to the classifier as possible. For a specific type of signal, most of these features would then be uninformative. Unfortunately, it turns out in practice that this heavily decreases the sensitivity to that signal. The presence of a small signal within an overwhelming background is more and more washed out in more and more noisy dimensions, making it much harder to detect for the NN. This challenge was discussed in more depth in [this paper](https://arxiv.org/abs/2309.13111), where a substantial improvement was achieved by **replacing the NN classifier by a boosted decision tree (BDT) classifier**. The very different inductive bias of tree-based classifiers makes them more resilient to noisy features.\n",
+    "\n",
+    "This notebook builds on `demos/weak_supervision.ipynb`, using the same dataset and the same NN classifier. We will then train a [Histogram-based Gradient Boosting Classification Tree](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.HistGradientBoostingClassifier.html) as an alternative to confirm it has similar performance as the NN when all features contain relevant information on the specific kind of signal that is present in the data. Then we will add ten uninformative features, simply by drawing random numbers from a normal distribution, and see how the two classifier models react differently. [The tree-based weak supervision paper](https://arxiv.org/abs/2309.13111) also discussed that the BDTs become even more stable at high amounts of noise if we *ensemble* them: train multiple BDTs with different train/validation splits and average their predictions. Thus, we will end the notebook with an implementation of such an emsemble model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "from os.path import exists, join, dirname, realpath\n",
+    "from sklearn.metrics import roc_curve\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.pipeline import make_pipeline\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from sklearn.utils import shuffle\n",
+    "\n",
+    "# adding parent directory to path\n",
+    "parent_dir = dirname(realpath(globals()[\"_dh\"][0]))\n",
+    "sys.path.append(parent_dir)\n",
+    "\n",
+    "from sk_cathode.classifier_models.boosted_decision_tree import HGBClassifier\n",
+    "from sk_cathode.classifier_models.neural_network_classifier import NeuralNetworkClassifier\n",
+    "from sk_cathode.utils.ensembling_utils import EnsembleModel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# :sunglasses:\n",
+    "plt.style.use('dark_background')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The same input data as in `demos/weak_supervision.ipynb` are used here. We make use of the same separation into train/validation/test data. However, we don't make use of the extra train/validation signal, as we won't train a supervised classifier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_path = \"./input_data/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# data preparation (download and high-level preprocessing)\n",
+    "if not exists(join(data_path, \"innerdata_test.npy\")):\n",
+    "    process = subprocess.run(f\"{sys.executable} {join(parent_dir, 'demos', 'utils', 'data_preparation.py')} --outdir {data_path}\", shell=True, check=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# data loading\n",
+    "innerdata_train = np.load(join(data_path, \"innerdata_train.npy\"))\n",
+    "innerdata_val = np.load(join(data_path, \"innerdata_val.npy\"))\n",
+    "innerdata_test = np.load(join(data_path, \"innerdata_test.npy\"))\n",
+    "innerdata_extrabkg_train = np.load(join(data_path, \"innerdata_extrabkg_train.npy\"))\n",
+    "innerdata_extrabkg_val = np.load(join(data_path, \"innerdata_extrabkg_val.npy\"))\n",
+    "innerdata_extrabkg_test = np.load(join(data_path, \"innerdata_extrabkg_test.npy\"))\n",
+    "innerdata_extrasig = np.load(join(data_path, \"innerdata_extrasig.npy\"))\n",
+    "\n",
+    "# Enriching the test set with extra signal.\n",
+    "# We could use all, but this way it's consistent with previous notebooks.\n",
+    "innerdata_extrasig_test = innerdata_extrasig[:20000]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As in `demos/weak_supervision.ipynb`, we train a classifier to distinguish between \"data\" and a pure background. We first start by again using a neural network. We even use the same model path, so we can recycle the previous one if it was trained in the other notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# assigning label 1 to \"data\"\n",
+    "clsf_train_data = innerdata_train.copy()\n",
+    "clsf_train_data[:, -1] = np.ones_like(clsf_train_data[:, -1])\n",
+    "clsf_val_data = innerdata_val.copy()\n",
+    "clsf_val_data[:, -1] = np.ones_like(clsf_val_data[:, -1])\n",
+    "\n",
+    "# and label 0 to background\n",
+    "clsf_train_bkg = innerdata_extrabkg_train.copy()\n",
+    "clsf_train_bkg[:, -1] = np.zeros_like(clsf_train_bkg[:, -1])\n",
+    "clsf_val_bkg = innerdata_extrabkg_val.copy()\n",
+    "clsf_val_bkg[:, -1] = np.zeros_like(clsf_val_bkg[:, -1])\n",
+    "\n",
+    "# mixing together and shuffling\n",
+    "clsf_train_set = np.vstack([clsf_train_data, clsf_train_bkg])\n",
+    "clsf_val_set = np.vstack([clsf_val_data, clsf_val_bkg])\n",
+    "clsf_train_set = shuffle(clsf_train_set, random_state=42)\n",
+    "clsf_val_set = shuffle(clsf_val_set, random_state=42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# either train new NN classifier to distinguish between \"data\" and background\n",
+    "\n",
+    "scaler = StandardScaler()\n",
+    "scaler.fit(clsf_train_set[:, 1:-1])\n",
+    "\n",
+    "X_train = scaler.transform(clsf_train_set[:, 1:-1])\n",
+    "y_train = clsf_train_set[:, -1]\n",
+    "X_val = scaler.transform(clsf_val_set[:, 1:-1])\n",
+    "y_val = clsf_val_set[:, -1]\n",
+    "\n",
+    "nn_classifier_savedir = \"./trained_classifiers_idealized-ad_0/\"\n",
+    "# Let's protect ourselves from accidentally overwriting a trained model.\n",
+    "if not exists(join(nn_classifier_savedir, \"CLSF_models\")):\n",
+    "    nn_classifier_model = NeuralNetworkClassifier(save_path=nn_classifier_savedir,\n",
+    "                                                  n_inputs=X_train.shape[1],\n",
+    "                                                  early_stopping=True, epochs=None,\n",
+    "                                                  verbose=True)\n",
+    "    nn_classifier_model.fit(X_train, y_train, X_val, y_val)\n",
+    "\n",
+    "    # merge scaler and classifier into a single pipeline\n",
+    "    nn_full_model = make_pipeline(scaler, nn_classifier_model)\n",
+    "else:\n",
+    "    print(f\"The model exists already in {nn_classifier_savedir}. Remove first if you want to overwrite.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# or alternatively load existing classifer model\n",
+    "\n",
+    "scaler = StandardScaler()\n",
+    "scaler.fit(clsf_train_set[:, 1:-1])\n",
+    "\n",
+    "nn_classifier_savedir = \"./trained_classifiers_idealized-ad_0/\"\n",
+    "nn_classifier_model = NeuralNetworkClassifier(save_path=nn_classifier_savedir,\n",
+    "                                              n_inputs=clsf_train_set[:, 1:-1].shape[1],\n",
+    "                                              load=True)\n",
+    "nn_full_model = make_pipeline(scaler, nn_classifier_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again, we use significance improvement characteristic (SIC) curves to evalaute the sensitivity to this specific test signal in the LHCO data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# now let's evaluate the signal extraction performance on the same test set\n",
+    "\n",
+    "clsf_test_set = np.vstack([innerdata_test,\n",
+    "                           innerdata_extrabkg_test,\n",
+    "                           innerdata_extrasig_test])\n",
+    "\n",
+    "X_test = clsf_test_set[:, 1:-1]\n",
+    "y_test = clsf_test_set[:, -1]\n",
+    "\n",
+    "nn_preds_test = nn_full_model.predict(X_test).flatten()\n",
+    "\n",
+    "with np.errstate(divide='ignore', invalid='ignore'):\n",
+    "    nn_fpr, nn_tpr, _ = roc_curve(y_test, nn_preds_test)\n",
+    "    nn_bkg_rej = 1 / nn_fpr\n",
+    "    nn_sic = nn_tpr / np.sqrt(nn_fpr)\n",
+    "\n",
+    "    random_tpr = np.linspace(0, 1, 300)\n",
+    "    random_bkg_rej = 1 / random_tpr\n",
+    "    random_sic = random_tpr / np.sqrt(random_tpr)\n",
+    "\n",
+    "# SIC curve\n",
+    "plt.plot(nn_tpr, nn_sic, label=\"idealized AD, NN\")\n",
+    "plt.plot(random_tpr, random_sic, \"w:\", label=\"random\")\n",
+    "plt.xlabel(\"True Positive Rate\")\n",
+    "plt.ylabel(\"Significance Improvement\")\n",
+    "plt.legend(loc=\"upper right\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we reproduced the neural network benchmark on the default four high-level input features of the LHCO data, let's train a Histogram-based Gradient Boosting Classification Tree on the exact same input data. Our implementation here wraps the scikit-learn implementation in a way to have more control over the validation loss and add the same model saving/loading functionality as we have in the neural network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# either train new HistGradientBoosting classifier to distinguish between \"data\" and background\n",
+    "\n",
+    "# note that the scaler here is the same as we used for the NN\n",
+    "scaler = StandardScaler()\n",
+    "scaler.fit(clsf_train_set[:, 1:-1])\n",
+    "\n",
+    "X_train = scaler.transform(clsf_train_set[:, 1:-1])\n",
+    "y_train = clsf_train_set[:, -1]\n",
+    "X_val = scaler.transform(clsf_val_set[:, 1:-1])\n",
+    "y_val = clsf_val_set[:, -1]\n",
+    "\n",
+    "bdt_classifier_savedir = \"./trained_classifiers_tree_idealized-ad_0/\"\n",
+    "# Let's protect ourselves from accidentally overwriting a trained model.\n",
+    "if not exists(join(bdt_classifier_savedir, \"CLSF_models\")):\n",
+    "    bdt_classifier_model = HGBClassifier(save_path=bdt_classifier_savedir,\n",
+    "                                         early_stopping=True, max_iters=None,\n",
+    "                                         verbose=True)\n",
+    "    bdt_classifier_model.fit(X_train, y_train, X_val, y_val)\n",
+    "\n",
+    "    # merge scaler and classifier into a single pipeline\n",
+    "    bdt_full_model = make_pipeline(scaler, bdt_classifier_model)\n",
+    "else:\n",
+    "    print(f\"The model exists already in {bdt_classifier_savedir}. Remove first if you want to overwrite.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# or alternatively load existing classifer model\n",
+    "\n",
+    "scaler = StandardScaler()\n",
+    "scaler.fit(clsf_train_set[:, 1:-1])\n",
+    "\n",
+    "bdt_classifier_savedir = \"./trained_classifiers_tree_idealized-ad_0/\"\n",
+    "bdt_classifier_model = HGBClassifier(save_path=bdt_classifier_savedir,\n",
+    "                                     load=True)\n",
+    "bdt_full_model = make_pipeline(scaler, bdt_classifier_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# now let's evaluate the signal extraction performance on the same test set\n",
+    "\n",
+    "clsf_test_set = np.vstack([innerdata_test,\n",
+    "                           innerdata_extrabkg_test,\n",
+    "                           innerdata_extrasig_test])\n",
+    "\n",
+    "X_test = clsf_test_set[:, 1:-1]\n",
+    "y_test = clsf_test_set[:, -1]\n",
+    "\n",
+    "bdt_preds_test = bdt_full_model.predict(X_test).flatten()\n",
+    "\n",
+    "with np.errstate(divide='ignore', invalid='ignore'):\n",
+    "    bdt_fpr, bdt_tpr, _ = roc_curve(y_test, bdt_preds_test)\n",
+    "    bdt_bkg_rej = 1 / bdt_fpr\n",
+    "    bdt_sic = bdt_tpr / np.sqrt(bdt_fpr)\n",
+    "\n",
+    "    random_tpr = np.linspace(0, 1, 300)\n",
+    "    random_bkg_rej = 1 / random_tpr\n",
+    "    random_sic = random_tpr / np.sqrt(random_tpr)\n",
+    "\n",
+    "# SIC curve\n",
+    "plt.plot(bdt_tpr, bdt_sic, label=\"idealized AD, BDT\")\n",
+    "plt.plot(random_tpr, random_sic, \"w:\", label=\"random\")\n",
+    "plt.xlabel(\"True Positive Rate\")\n",
+    "plt.ylabel(\"Significance Improvement\")\n",
+    "plt.legend(loc=\"upper right\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The performance in terms of SICs should be roughly the same on these input data. Of course, there is some run-by-run variance, which we could quantify more thoroughly by plotting the median and 68% CL bands, as in the end of `demos/weak_supervision.ipynb`. But for a first check we see that the BDT performs similarly to the NN, while being significantly faster to train.\n",
+    "\n",
+    "Now let's put the two models to the test of how they react to uninformative features. We will add ten features of pure Gaussian noise (thus abbreviating to 10G), without any discrimination power between signal and background. Thus, most input dimensions will now be useless for the classification task."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def add_n_noise_features(X, n=10):\n",
+    "    # note that the last column is the signal-vs-background label\n",
+    "    data = X[:, :-1]\n",
+    "    labels = X[:, -1:]\n",
+    "    noise = np.random.normal(size=(X.shape[0], n))\n",
+    "    return np.hstack([data, noise, labels])\n",
+    "\n",
+    "\n",
+    "# we consistently add the noise to training, validation and test set\n",
+    "innerdata_train_noisy = add_n_noise_features(innerdata_train)\n",
+    "innerdata_val_noisy = add_n_noise_features(innerdata_val)\n",
+    "innerdata_test_noisy = add_n_noise_features(innerdata_test)\n",
+    "\n",
+    "innerdata_extrabkg_train_noisy = add_n_noise_features(innerdata_extrabkg_train)\n",
+    "innerdata_extrabkg_val_noisy = add_n_noise_features(innerdata_extrabkg_val)\n",
+    "innerdata_extrabkg_test_noisy = add_n_noise_features(innerdata_extrabkg_test)\n",
+    "\n",
+    "innerdata_extrasig_test_noisy = add_n_noise_features(innerdata_extrasig_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# assigning label 1 to \"data\"\n",
+    "clsf_train_data_noisy = innerdata_train_noisy.copy()\n",
+    "clsf_train_data_noisy[:, -1] = np.ones_like(clsf_train_data_noisy[:, -1])\n",
+    "clsf_val_data_noisy = innerdata_val_noisy.copy()\n",
+    "clsf_val_data_noisy[:, -1] = np.ones_like(clsf_val_data_noisy[:, -1])\n",
+    "\n",
+    "# and label 0 to background\n",
+    "clsf_train_bkg_noisy = innerdata_extrabkg_train_noisy.copy()\n",
+    "clsf_train_bkg_noisy[:, -1] = np.zeros_like(clsf_train_bkg_noisy[:, -1])\n",
+    "clsf_val_bkg_noisy = innerdata_extrabkg_val_noisy.copy()\n",
+    "clsf_val_bkg_noisy[:, -1] = np.zeros_like(clsf_val_bkg_noisy[:, -1])\n",
+    "\n",
+    "# mixing together and shuffling\n",
+    "clsf_train_set_noisy = np.vstack([clsf_train_data_noisy, clsf_train_bkg_noisy])\n",
+    "clsf_val_set_noisy = np.vstack([clsf_val_data_noisy, clsf_val_bkg_noisy])\n",
+    "clsf_train_set_noisy = shuffle(clsf_train_set_noisy, random_state=42)\n",
+    "clsf_val_set_noisy = shuffle(clsf_val_set_noisy, random_state=42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# either train new NN classifier\n",
+    "\n",
+    "scaler_noisy = StandardScaler()\n",
+    "scaler_noisy.fit(clsf_train_set_noisy[:, 1:-1])\n",
+    "\n",
+    "X_train = scaler_noisy.transform(clsf_train_set_noisy[:, 1:-1])\n",
+    "y_train = clsf_train_set_noisy[:, -1]\n",
+    "X_val = scaler_noisy.transform(clsf_val_set_noisy[:, 1:-1])\n",
+    "y_val = clsf_val_set_noisy[:, -1]\n",
+    "\n",
+    "nn_classifier_savedir_noisy = \"./trained_classifiers_idealized-ad_10G_0/\"\n",
+    "# Let's protect ourselves from accidentally overwriting a trained model.\n",
+    "if not exists(join(nn_classifier_savedir_noisy, \"CLSF_models\")):\n",
+    "    nn_classifier_model_noisy = NeuralNetworkClassifier(save_path=nn_classifier_savedir_noisy,\n",
+    "                                                        n_inputs=X_train.shape[1],\n",
+    "                                                        early_stopping=True, epochs=None,\n",
+    "                                                        verbose=True)\n",
+    "    nn_classifier_model_noisy.fit(X_train, y_train, X_val, y_val)\n",
+    "\n",
+    "    # merge scaler and classifier into a single pipeline\n",
+    "    nn_full_model_noisy = make_pipeline(scaler_noisy, nn_classifier_model_noisy)\n",
+    "else:\n",
+    "    print(f\"The model exists already in {nn_classifier_savedir_noisy}. Remove first if you want to overwrite.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# or alternatively load existing classifer model\n",
+    "\n",
+    "scaler_noisy = StandardScaler()\n",
+    "scaler_noisy.fit(clsf_train_set_noisy[:, 1:-1])\n",
+    "\n",
+    "nn_classifier_savedir_noisy = \"./trained_classifiers_idealized-ad_10G_0/\"\n",
+    "nn_classifier_model_noisy = NeuralNetworkClassifier(save_path=nn_classifier_savedir_noisy,\n",
+    "                                                    n_inputs=clsf_train_set_noisy[:, 1:-1].shape[1],\n",
+    "                                                    load=True)\n",
+    "nn_full_model_noisy = make_pipeline(scaler_noisy, nn_classifier_model_noisy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# now let's evaluate the signal extraction performance on the same test set\n",
+    "\n",
+    "clsf_test_set_noisy = np.vstack([innerdata_test_noisy,\n",
+    "                           innerdata_extrabkg_test_noisy,\n",
+    "                           innerdata_extrasig_test_noisy])\n",
+    "\n",
+    "X_test_noisy = clsf_test_set_noisy[:, 1:-1]\n",
+    "y_test_noisy = clsf_test_set_noisy[:, -1]\n",
+    "\n",
+    "nn_preds_test_noisy = nn_full_model_noisy.predict(X_test_noisy).flatten()\n",
+    "\n",
+    "with np.errstate(divide='ignore', invalid='ignore'):\n",
+    "    nn_fpr_noisy, nn_tpr_noisy, _ = roc_curve(y_test_noisy, nn_preds_test_noisy)\n",
+    "    nn_bkg_rej_noisy = 1 / nn_fpr_noisy\n",
+    "    nn_sic_noisy = nn_tpr_noisy / np.sqrt(nn_fpr_noisy)\n",
+    "\n",
+    "    random_tpr = np.linspace(0, 1, 300)\n",
+    "    random_bkg_rej = 1 / random_tpr\n",
+    "    random_sic = random_tpr / np.sqrt(random_tpr)\n",
+    "\n",
+    "# SIC curve\n",
+    "plt.plot(nn_tpr_noisy, nn_sic_noisy, label=\"idealized AD, NN, 10G\")\n",
+    "plt.plot(random_tpr, random_sic, \"w:\", label=\"random\")\n",
+    "plt.xlabel(\"True Positive Rate\")\n",
+    "plt.ylabel(\"Significance Improvement\")\n",
+    "plt.legend(loc=\"upper right\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The neural network reacts poorly to this change, with only a fraction of the previous SIC left :("
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# either train new BDT classifier\n",
+    "\n",
+    "scaler_noisy = StandardScaler()\n",
+    "scaler_noisy.fit(clsf_train_set_noisy[:, 1:-1])\n",
+    "\n",
+    "X_train = scaler_noisy.transform(clsf_train_set_noisy[:, 1:-1])\n",
+    "y_train = clsf_train_set_noisy[:, -1]\n",
+    "X_val = scaler_noisy.transform(clsf_val_set_noisy[:, 1:-1])\n",
+    "y_val = clsf_val_set_noisy[:, -1]\n",
+    "\n",
+    "bdt_classifier_savedir_noisy = \"./trained_classifiers_tree_idealized-ad_10G_0/\"\n",
+    "# Let's protect ourselves from accidentally overwriting a trained model.\n",
+    "if not exists(join(bdt_classifier_savedir_noisy, \"CLSF_models\")):\n",
+    "    bdt_classifier_model_noisy = HGBClassifier(save_path=bdt_classifier_savedir_noisy,\n",
+    "                                               early_stopping=True, max_iters=None,\n",
+    "                                               verbose=True)\n",
+    "    bdt_classifier_model_noisy.fit(X_train, y_train, X_val, y_val)\n",
+    "\n",
+    "    # merge scaler and classifier into a single pipeline\n",
+    "    bdt_full_model_noisy = make_pipeline(scaler_noisy, bdt_classifier_model_noisy)\n",
+    "else:\n",
+    "    print(f\"The model exists already in {bdt_classifier_savedir_noisy}. Remove first if you want to overwrite.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# or alternatively load existing classifer model\n",
+    "\n",
+    "scaler_noisy = StandardScaler()\n",
+    "scaler_noisy.fit(clsf_train_set_noisy[:, 1:-1])\n",
+    "\n",
+    "bdt_classifier_savedir_noisy = \"./trained_classifiers_tree_idealized-ad_10G_0/\"\n",
+    "bdt_classifier_model_noisy = HGBClassifier(save_path=bdt_classifier_savedir_noisy,\n",
+    "                                           load=True)\n",
+    "bdt_full_model_noisy = make_pipeline(scaler_noisy, bdt_classifier_model_noisy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# now let's evaluate the signal extraction performance on the same test set\n",
+    "\n",
+    "clsf_test_set_noisy = np.vstack([innerdata_test_noisy,\n",
+    "                                 innerdata_extrabkg_test_noisy,\n",
+    "                                 innerdata_extrasig_test_noisy])\n",
+    "\n",
+    "X_test_noisy = clsf_test_set_noisy[:, 1:-1]\n",
+    "y_test_noisy = clsf_test_set_noisy[:, -1]\n",
+    "\n",
+    "bdt_preds_test_noisy = bdt_full_model_noisy.predict(X_test_noisy).flatten()\n",
+    "\n",
+    "with np.errstate(divide='ignore', invalid='ignore'):\n",
+    "    bdt_fpr_noisy, bdt_tpr_noisy, _ = roc_curve(y_test_noisy, bdt_preds_test_noisy)\n",
+    "    bdt_bkg_rej_noisy = 1 / bdt_fpr_noisy\n",
+    "    bdt_sic_noisy = bdt_tpr_noisy / np.sqrt(bdt_fpr_noisy)\n",
+    "\n",
+    "    random_tpr = np.linspace(0, 1, 300)\n",
+    "    random_bkg_rej = 1 / random_tpr\n",
+    "    random_sic = random_tpr / np.sqrt(random_tpr)\n",
+    "\n",
+    "# SIC curve\n",
+    "plt.plot(bdt_tpr_noisy, bdt_sic_noisy, label=\"idealized AD, BDT, 10G\")\n",
+    "plt.plot(random_tpr, random_sic, \"w:\", label=\"random\")\n",
+    "plt.xlabel(\"True Positive Rate\")\n",
+    "plt.ylabel(\"Significance Improvement\")\n",
+    "plt.legend(loc=\"upper right\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There is likely also a drop in performance in the BDT, compared to before, but the remaining SIC is substantially higher than the NN case. Plus, it was much faster to train.\n",
+    "\n",
+    "But to get more out of the BDT, we should train an ensemble of multiple BDTs, each with a different separation into training and validation data. Since BDTs train so fast, this is not really a problem. We use an ensemble of ten models here for illustration, but we could do even better with larger ensembles.\n",
+    "\n",
+    "We conveniently implement the model here with a wrapper class `EnsembleModel`, which has the same API as a single model and takes care of the averaging of provided models under the hood."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# mix together train and validation set for different splits\n",
+    "innerdata_train_val_noisy = np.vstack([innerdata_train_noisy,\n",
+    "                                       innerdata_val_noisy])\n",
+    "innerdata_extrabkg_train_val_noisy = np.vstack([innerdata_extrabkg_train_noisy,\n",
+    "                                                innerdata_extrabkg_val_noisy])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# train ensemble of trees with different train/val splits\n",
+    "n_classifiers = 10\n",
+    "\n",
+    "model_noisy_list = []\n",
+    "for i in range(n_classifiers):\n",
+    "\n",
+    "    # different split per classifier\n",
+    "    # (could also do this more controlled via a fixed k-folding scheme)\n",
+    "    _innerdata_train, _innerdata_val = train_test_split(\n",
+    "        innerdata_train_val_noisy, train_size=0.8, random_state=1337+i)\n",
+    "    _innerdata_extrabkg_train, _innerdata_extrabkg_val = train_test_split(\n",
+    "        innerdata_extrabkg_train_val_noisy, train_size=0.8, random_state=1337+i)\n",
+    "\n",
+    "    # assigning label 1 to \"data\"\n",
+    "    _clsf_train_data = _innerdata_train\n",
+    "    _clsf_train_data[:, -1] = np.ones_like(_clsf_train_data[:, -1])\n",
+    "    _clsf_val_data = _innerdata_val\n",
+    "    _clsf_val_data[:, -1] = np.ones_like(_clsf_val_data[:, -1])\n",
+    "\n",
+    "    # and label 0 to background\n",
+    "    _clsf_train_bkg = _innerdata_extrabkg_train\n",
+    "    _clsf_train_bkg[:, -1] = np.zeros_like(_clsf_train_bkg[:, -1])\n",
+    "    _clsf_val_bkg = _innerdata_extrabkg_val\n",
+    "    _clsf_val_bkg[:, -1] = np.zeros_like(_clsf_val_bkg[:, -1])\n",
+    "\n",
+    "    # mixing together and shuffling\n",
+    "    _clsf_train_set = np.vstack([_clsf_train_data, _clsf_train_bkg])\n",
+    "    _clsf_val_set = np.vstack([_clsf_val_data, _clsf_val_bkg])\n",
+    "    _clsf_train_set = shuffle(_clsf_train_set, random_state=42)\n",
+    "    _clsf_val_set = shuffle(_clsf_val_set, random_state=42)\n",
+    "\n",
+    "    # fit scaler\n",
+    "    _scaler = StandardScaler()\n",
+    "    _scaler.fit(_clsf_train_set[:, 1:-1])\n",
+    "\n",
+    "    # train classifier\n",
+    "    _classifier_savedir = f\"./trained_classifier_idealized-ad_ensemble_10G/model_{i}/\"\n",
+    "    _classifier = HGBClassifier(save_path=_classifier_savedir,\n",
+    "                                early_stopping=True, max_iters=None,\n",
+    "                                verbose=False)\n",
+    "\n",
+    "    # We don't want to overwrite the model if it already exists.\n",
+    "    if not exists(join(_classifier_savedir, \"CLSF_models\")):\n",
+    "        X_train = _scaler.transform(_clsf_train_set[:, 1:-1])\n",
+    "        y_train = _clsf_train_set[:, -1]\n",
+    "        X_val = _scaler.transform(_clsf_val_set[:, 1:-1])\n",
+    "        y_val = _clsf_val_set[:, -1]\n",
+    "        _classifier.fit(X_train, y_train, X_val, y_val)\n",
+    "    else:\n",
+    "        print(f\"The model exists already in {_classifier_savedir}. Remove first if you want to overwrite. Loading its best state now.\")\n",
+    "        _classifier.load_best_model()\n",
+    "\n",
+    "    # merge scaler and classifier into a single pipeline model\n",
+    "    _pipeline = make_pipeline(_scaler, _classifier)\n",
+    "    model_noisy_list.append(_pipeline)\n",
+    "\n",
+    "# Now merging all these models into a single ensemble model\n",
+    "ensemble_noisy = EnsembleModel(model_noisy_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# now let's evaluate the signal extraction performance on the same test set\n",
+    "\n",
+    "clsf_test_set_noisy = np.vstack([innerdata_test_noisy,\n",
+    "                                 innerdata_extrabkg_test_noisy,\n",
+    "                                 innerdata_extrasig_test_noisy])\n",
+    "\n",
+    "X_test_noisy = clsf_test_set_noisy[:, 1:-1]\n",
+    "y_test_noisy = clsf_test_set_noisy[:, -1]\n",
+    "\n",
+    "ensemble_preds_test_noisy = ensemble_noisy.predict(X_test_noisy).flatten()\n",
+    "\n",
+    "with np.errstate(divide='ignore', invalid='ignore'):\n",
+    "    ensemble_fpr_noisy, ensemble_tpr_noisy, _ = roc_curve(y_test_noisy, ensemble_preds_test_noisy)\n",
+    "    ensemble_bkg_rej_noisy = 1 / ensemble_fpr_noisy\n",
+    "    ensemble_sic_noisy = ensemble_tpr_noisy / np.sqrt(ensemble_fpr_noisy)\n",
+    "\n",
+    "    random_tpr = np.linspace(0, 1, 300)\n",
+    "    random_bkg_rej = 1 / random_tpr\n",
+    "    random_sic = random_tpr / np.sqrt(random_tpr)\n",
+    "\n",
+    "# SIC curve\n",
+    "plt.plot(ensemble_tpr_noisy, ensemble_sic_noisy, label=\"idealized AD, BDT ensemble, 10G\")\n",
+    "plt.plot(random_tpr, random_sic, \"w:\", label=\"random\")\n",
+    "plt.xlabel(\"True Positive Rate\")\n",
+    "plt.ylabel(\"Significance Improvement\")\n",
+    "plt.legend(loc=\"upper right\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We should see another substantial improvement compared to the single tree model. In fact, the performance of an ensemble model tends to be higher than the performance of each individual model that go into the ensemble, i.e. it's not just trivially averaging out the run-by-run variance. A way to understand this is that a single event might get a high (close to 1) prediction by one model but background-like (close to 0.5) prediction by the others. The average of these predictions is still shifted upwards compared to the case where all models agree on a background-like prediction. NNs can also benefit from this type of ensembling, but in this case it will not be sufficient to recover the performance drop due to the noise, plus their longer training times makes ensembling less cheap.\n",
+    "\n",
+    "In summary, we have now seen that BDTs are a nice alternative to neural networks in weakly supervised anomaly detection for two reasons:\n",
+    "\n",
+    "1) they are more resilient to uninformative input features\n",
+    "2) they are much faster to train\n",
+    "\n",
+    "The latter point makes it very attractive to squeeze out more performance by ensembling over many individually trained BDTs (which are technically also making use of ensembling under the hood individually)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "NotebookEnv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/sk_cathode/classifier_models/boosted_decision_tree.py
+++ b/sk_cathode/classifier_models/boosted_decision_tree.py
@@ -176,11 +176,13 @@ class HGBClassifier(BaseEstimator):
             print("Loading best model state...")
             self.load_best_model()
 
+        return self
+
     def predict(self, X):
         # The sklearn BDT predicts integer class labels. However, here we work
         # with binary classification and we want the freedom to choose our own
         # working point. Thus, let's return the 1-class probabilities instead.
-        return self.model.predict_proba(X)[:, 1]
+        return self.model.predict_proba(X)[:, 1:2]
 
     def predict_proba(self, X):
         return self.model.predict_proba(X)

--- a/sk_cathode/classifier_models/boosted_decision_tree.py
+++ b/sk_cathode/classifier_models/boosted_decision_tree.py
@@ -1,0 +1,254 @@
+# wrapping the BDT classifer in a sklearn-like API
+# heavily inspired by Tobias Quadfasel's work
+# at https://github.com/uhh-pd-ml/treebased_ad
+
+import joblib
+import numpy as np
+from copy import deepcopy
+from os import makedirs
+from os.path import join
+from sklearn.base import BaseEstimator
+from sklearn.metrics import log_loss
+from sklearn.model_selection import train_test_split
+from sklearn.ensemble import HistGradientBoostingClassifier
+from sklearn.utils import class_weight
+
+
+class HGBClassifier(BaseEstimator):
+
+    def __init__(self, *args, save_path=None, load=False,
+                 max_bins=127,  early_stopping=True,
+                 patience=10, max_iters=100, val_split=0.2,
+                 split_seed=None, use_class_weights=True, verbose=False,
+                 **kwargs):
+
+        self.save_path = save_path
+        if save_path is not None:
+            self.clsf_model_path = join(save_path, "CLSF_models/")
+        else:
+            self.clsf_model_path = None
+
+        self.max_iters = max_iters
+        self.early_stopping = early_stopping
+        self.load = load
+        self.max_bins = max_bins
+        self.patience = patience
+        self.val_split = val_split
+        self.split_seed = split_seed
+        self.use_class_weights = use_class_weights
+        self.verbose = verbose
+        self.args = args
+        self.kwargs = kwargs
+
+        self.model = HistGradientBoostingClassifier(
+            *args, max_bins=max_bins, class_weight="balanced",
+            max_iter=1, early_stopping=False, warm_start=True,
+            **kwargs)
+
+        if split_seed is not None:
+            self.model.split_seed = split_seed
+
+        if load:
+            self.load_best_model()
+
+    def fit(self, X, y, X_val=None, y_val=None,
+            sample_weight=None, sample_weight_val=None):
+
+        assert not (self.max_iters is None and not self.early_stopping), (
+            "A finite number of iterations must be set if early stopping"
+            " is not used!")
+
+        # allowing not to provide validation set, just for compatibility with
+        # the sklearn API
+        if X_val is None and y_val is None:
+            if self.val_split is None or not (self.val_split > 0.
+                                              and self.val_split < 1.):
+                raise ValueError("val_split is needs to be provided and lie "
+                                 "between 0 and 1 in case X_val and y_val are "
+                                 "not provided!")
+            else:
+                if sample_weight is not None:
+                    (X_train, X_val, y_train, y_val,
+                     sample_weight_train, sample_weight_val
+                     ) = train_test_split(
+                        X, y, sample_weight, test_size=self.val_split,
+                        shuffle=True)
+                else:
+                    X_train, X_val, y_train, y_val = train_test_split(
+                        X, y, test_size=self.val_split, shuffle=True)
+        else:
+            X_train = X.copy()
+            y_train = y.copy()
+            if sample_weight is not None:
+                sample_weight_train = sample_weight.copy()
+            else:
+                sample_weight_train = None
+
+        if self.clsf_model_path is not None:
+            makedirs(self.clsf_model_path, exist_ok=True)
+
+        nan_mask = ~np.isnan(X_train).any(axis=1)
+        X_train = X_train[nan_mask]
+        y_train = y_train[nan_mask]
+        if sample_weight_train is not None:
+            sample_weight_train = sample_weight_train[nan_mask]
+
+        nan_mask = ~np.isnan(X_val).any(axis=1)
+        X_val = X_val[nan_mask]
+        y_val = y_val[nan_mask]
+        if sample_weight_val is not None:
+            sample_weight_val = sample_weight_val[nan_mask]
+
+        # deduce class weights for training and validation sets
+        # and translate them to sample weights
+        # (move outside class as in sklearn?)
+        if self.use_class_weights:
+            class_weights_train = class_weight.compute_class_weight(
+                'balanced', classes=np.unique(y_train), y=y_train)
+            class_weights_train = dict(enumerate(class_weights_train))
+            sample_weight_train_ = class_weight_to_sample_weight(
+                y_train, class_weights_train)
+
+            if sample_weight_train is None:
+                sample_weight_train = sample_weight_train_
+            else:
+                sample_weight_train = sample_weight.copy()
+                sample_weight_train *= sample_weight_train_
+
+            class_weights_val = class_weight.compute_class_weight(
+                'balanced', classes=np.unique(y_val), y=y_val)
+            class_weights_val = dict(enumerate(class_weights_val))
+            sample_weight_val_ = class_weight_to_sample_weight(
+                y_val, class_weights_val)
+
+            if sample_weight_val is None:
+                sample_weight_val = sample_weight_val_
+            else:
+                sample_weight_val = sample_weight_val.copy()
+                sample_weight_val *= sample_weight_val_
+
+        min_val_loss = np.inf
+        train_losses = []
+        val_losses = []
+        for i in range(self.max_iters
+                       if self.max_iters is not None else 10000):
+            if self.verbose:
+                print(f"training iteration {i}...")
+            self.model.fit(X, y)
+
+            train_preds = self.model.predict_proba(X)[:, 1]
+            train_loss = log_loss(y, train_preds,
+                                  sample_weight=sample_weight_train)
+
+            val_preds = self.model.predict_proba(X_val)[:, 1]
+            val_loss = log_loss(y_val, val_preds,
+                                sample_weight=sample_weight_val)
+
+            train_losses.append(train_loss)
+            val_losses.append(val_loss)
+
+            if self.verbose:
+                print(f"\ttrain loss: {train_loss}, val loss: {val_loss}")
+
+            if val_loss < min_val_loss-1e-7:
+                min_val_loss = val_loss
+                iter_diff = 0
+                self.model.best_model_state = deepcopy(self.model)
+                self.model.best_iter = i
+            else:
+                iter_diff += 1
+
+            if self.early_stopping and (iter_diff >= self.patience):
+                print("Early stopping at iteration", i)
+                break
+
+            self.model.max_iter += 1
+
+        self.model.train_losses = train_losses
+        self.model.val_losses = val_losses
+
+        # in contrast to the NN, all iterations are saved in a single file
+        if self.save_path is not None:
+            self._save_model(self._model_path())
+            np.save(self._train_loss_path(), train_losses)
+            np.save(self._val_loss_path(), val_losses)
+
+            print("Loading best model state...")
+            self.load_best_model()
+
+    def predict(self, X):
+        # The sklearn BDT predicts integer class labels. However, here we work
+        # with binary classification and we want the freedom to choose our own
+        # working point. Thus, let's return the 1-class probabilities instead.
+        return self.model.predict_proba(X)[:, 1]
+
+    def predict_proba(self, X):
+        return self.model.predict_proba(X)
+
+    def score(self, X, y, sample_weight=None):
+        return self.model.score(X, y, sample_weight=sample_weight)
+
+    def load_best_model(self):
+        """Loads the best model state from the provided save_path.
+        """
+        self._load_model(self._model_path())
+        self.model = self.model.best_model_state
+
+    def load_train_loss(self):
+        """Loads the training loss from the provided save_path.
+
+        Returns
+        -------
+        train_loss : numpy.ndarray
+            Training loss.
+        """
+        if self.save_path is None:
+            raise ValueError("save_path is None, cannot load train loss")
+        return np.load(self._train_loss_path())
+
+    def load_val_loss(self):
+        """Loads the validation loss from the provided save_path.
+
+        Returns
+        -------
+        val_loss : numpy.ndarray
+            Validation loss.
+        """
+        if self.save_path is None:
+            raise ValueError("save_path is None, cannot load val loss")
+        return np.load(self._val_loss_path())
+
+    def _load_model(self, model_path):
+        self.model = joblib.load(model_path)
+
+    def _save_model(self, model_path):
+        joblib.dump(self.model, model_path)
+
+    def _train_loss_path(self):
+        return join(self.save_path, "CLSF_train_losses.npy")
+
+    def _val_loss_path(self):
+        return join(self.save_path, "CLSF_val_losses.npy")
+
+    def _model_path(self):
+        return join(self.clsf_model_path, "CLSF_model.joblib")
+
+
+def class_weight_to_sample_weight(y, class_weights):
+    """Converts class weights to sample weights.
+
+    Parameters
+    ----------
+    y : numpy.array
+        Target data.
+    class_weights : dict
+        Class weights.
+
+    Returns
+    -------
+    sample_weights : numpy.array
+        Sample weights.
+    """
+
+    return ((np.ones(y.shape) - y)
+            * class_weights[0] + y*class_weights[1])

--- a/sk_cathode/classifier_models/boosted_decision_tree.py
+++ b/sk_cathode/classifier_models/boosted_decision_tree.py
@@ -15,10 +15,16 @@ from sklearn.utils import class_weight
 
 
 class HGBClassifier(BaseEstimator):
-    """HistGradientBoosting tree classifier based on torch but wrapped such
-    that it mimicks the scikit-learn API, using numpy arrays as inputs
-    and outputs. In addition to the explicit parameters, more arguments can
-    be passed, specific to the sklearn HistGradientBoostingClassifier.
+    """Wrapper class of the HistGradientBoosting tree classifier by
+    scikit-learn. This implementation hacks around the sklearn core such that
+    one has more control over the validation set, i.e. we can pass an explicit
+    validation set with weights and can use early stopping based on that.
+    The predict method returns the 1-class probabilities instead of the
+    integer class labels, because we want to have the freedom to
+    choose our own working point.
+    Moreover, functionality for saving and loading models is added.
+    In addition to the explicit parameters, more arguments can be passed,
+    specific to the sklearn HistGradientBoostingClassifier.
 
     Parameters
     ----------
@@ -156,9 +162,6 @@ class HGBClassifier(BaseEstimator):
         if sample_weight_val is not None:
             sample_weight_val = sample_weight_val[nan_mask]
 
-        # deduce class weights for training and validation sets
-        # and translate them to sample weights
-        # (move outside class as in sklearn?)
         if self.use_class_weights:
             class_weights_train = class_weight.compute_class_weight(
                 'balanced', classes=np.unique(y_train), y=y_train)

--- a/sk_cathode/utils/ensembling_utils.py
+++ b/sk_cathode/utils/ensembling_utils.py
@@ -6,6 +6,23 @@ from sklearn.base import BaseEstimator
 
 
 class EnsembleModel(BaseEstimator):
+    """Wrapper class to combine multiple models into a single one.
+    The models need to share the API that should be accessed later.
+    E.g. ensemble_model.fit() will make the same call to the base models,
+    while ensemble_model.predict() will call the predict() method of each
+    base model and aggregate the results via the aggregation_func (default is
+    np.mean).
+
+    Parameters
+    ----------
+    base_model_list : list
+        List of models to be ensembled. They need to have the same API.
+    aggregation_func : function, default=np.mean
+        Function to aggregate predictions of base models.
+    avoid_overwriting : bool, default=False
+        If True, existing models will not be overwritten during training.
+    """
+
     def __init__(self, base_model_list, aggregation_func=np.mean,
                  avoid_overwriting=False):
         self.base_model_list = base_model_list
@@ -64,6 +81,17 @@ class EnsembleModel(BaseEstimator):
 
 
 class EpochEnsembleModel(EnsembleModel):
+    """Wrapper class to build an ensemble from multiple epochs of the
+    same training.
+
+    Parameters
+    ----------
+    base_model : BaseEstimator
+        Model to be ensembled.
+    n_best_epochs : int, default=10
+        Number of best epochs to be ensembled.
+    """
+
     def __init__(self, base_model, n_best_epochs=10):
         self.base_model = base_model
         self.n_best_epochs = n_best_epochs

--- a/sk_cathode/utils/ensembling_utils.py
+++ b/sk_cathode/utils/ensembling_utils.py
@@ -1,0 +1,83 @@
+import copy
+import numpy as np
+
+from os.path import exists
+from sklearn.base import BaseEstimator
+
+
+class EnsembleModel(BaseEstimator):
+    def __init__(self, base_model_list, aggregation_func=np.mean,
+                 avoid_overwriting=False):
+        self.base_model_list = base_model_list
+        self.aggregation_func = aggregation_func
+        self.avoid_overwriting = avoid_overwriting
+
+    def fit(self, *args, **kwargs):
+        for i, model in enumerate(self.base_model_list):
+            if self.avoid_overwriting:
+                try:
+                    does_exist = exists(model._model_path(0))
+                except AttributeError:
+                    does_exist = False
+                if does_exist:
+                    print(f"Model {i+1}/{len(self.base_model_list)} "
+                          f"already exists. Skipping training.")
+                    model.load_best_model()
+                    continue
+
+            print(f"Training model {i+1}/{len(self.base_model_list)}")
+            model.fit(*args, **kwargs)
+
+    def load_best_model(self, *args, **kwargs):
+        for model in self.base_model_list:
+            model.load_best_model(*args, **kwargs)
+
+    def predict(self, *args, **kwargs):
+        preds = []
+        for model in self.base_model_list:
+            preds.append(model.predict(*args, **kwargs))
+        return self.aggregation_func(np.stack(preds, axis=0), axis=0)
+
+    def predict_proba(self, *args, **kwargs):
+        preds = []
+        for model in self.base_model_list:
+            preds.append(model.predict_proba(*args, **kwargs))
+        return self.aggregation_func(np.stack(preds, axis=0), axis=0)
+
+    def transform(self, *args, **kwargs):
+        preds = []
+        for model in self.base_model_list:
+            preds.append(model.transform(*args, **kwargs))
+        return self.aggregation_func(np.stack(preds, axis=0), axis=0)
+
+    def sample(self, n_samples=1, **kwargs):
+        raise NotImplementedError
+
+    def predict_log_proba(self, *args, **kwargs):
+        return np.log(self.predict_proba(*args, **kwargs))
+
+    def score_samples(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def score(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class EpochEnsembleModel(EnsembleModel):
+    def __init__(self, base_model, n_best_epochs=10):
+        self.base_model = base_model
+        self.n_best_epochs = n_best_epochs
+        self.base_model_list = [base_model]
+
+    def fit(self, *args, **kwargs):
+        # only train base model
+        self.base_model.fit(*args, **kwargs)
+
+    def load_best_model(self):
+        val_loss = self.base_model.load_val_loss()
+        best_epochs = np.argsort(val_loss)[:self.n_best_epochs]
+        self.base_model_list = [
+            copy.deepcopy(self.base_model)
+            for _ in range(self.n_best_epochs)]
+        for i, epoch in enumerate(best_epochs):
+            self.base_model_list[i].load_epoch_model(epoch)

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -1,11 +1,13 @@
 import numpy as np
 import pytest
 
-from sk_cathode.classifier_models.neural_network_classifier import NeuralNetworkClassifier as ClassifierModel  # noqa
+from sk_cathode.classifier_models.neural_network_classifier import NeuralNetworkClassifier as ClassifierModelNN  # noqa
+from sk_cathode.classifier_models.boosted_decision_tree import HGBClassifier as ClassifierModelTree  # noqa
 
 
 classifier_models = [
-    ClassifierModel(epochs=1, save_path=None,),
+    ClassifierModelNN(epochs=1, save_path=None,),
+    ClassifierModelTree(max_iters=10, save_path=None,),
 ]
 X_test = np.random.rand(300, 4)
 y_test = np.random.randint(0, 2, 300)


### PR DESCRIPTION
Implementation of a Histogram-based Gradient Boosting Classification Tree as weakly supervised classifier and a notebook guide that explains why this is a good idea.

The core classifier is already provided by sci-kit learn and thus didn't need an extensive API change. However, in order to have full control over the validation loss, the wrapping class uses a few tricks that @loeschet discovered.

There is now also an `EnsembleModel` class that handily wraps multiple models such that it behaves like a single model and averages the individual ones under the hood.