### PR TITLE
adding the drop_last option to generative model training

### DIFF
--- a/sk_cathode/generative_models/conditional_flow_matching.py
+++ b/sk_cathode/generative_models/conditional_flow_matching.py
@@ -56,6 +56,9 @@ class ConditionalFlowMatching(BaseEstimator):
         effect if no validation set is provided to the fit method.
     batch_size : int, default=128
         Batch size during training.
+    drop_last : bool, default=True
+        Whether to drop the last training batch if it is smaller
+        than the batch size.
     epochs : int, default=100
         Number of epochs to train for. In case early stopping is used,
         this is treated as an upper limit. Then also None can be provided,
@@ -81,6 +84,7 @@ class ConditionalFlowMatching(BaseEstimator):
         no_gpu=False,
         val_split=0.2,
         batch_size=256,
+        drop_last=True,
         epochs=100,
         verbose=False
     ):
@@ -100,6 +104,7 @@ class ConditionalFlowMatching(BaseEstimator):
         self.patience = patience
         self.val_split = val_split
         self.batch_size = batch_size
+        self.drop_last = drop_last
         self.epochs = epochs
         self.verbose = verbose
 
@@ -191,11 +196,11 @@ class ConditionalFlowMatching(BaseEstimator):
         # build data loader out of numpy arrays
         train_loader = numpy_to_torch_loader(
             X_train, m_train, batch_size=self.batch_size, shuffle=True,
-            device=self.device
+            drop_last=self.drop_last, device=self.device
         )
         val_loader = numpy_to_torch_loader(
             X_val, m_val, batch_size=self.batch_size, shuffle=True,
-            device=self.device
+            drop_last=False, device=self.device
         )
 
         # record also untrained losses
@@ -440,7 +445,7 @@ class ConditionalFlowMatching(BaseEstimator):
 
 
 def numpy_to_torch_loader(X, m, batch_size=256, shuffle=True,
-                          device=torch.device("cpu")):
+                          drop_last=False, device=torch.device("cpu")):
     """Builds a torch DataLoader from numpy arrays.
 
     Parameters
@@ -453,6 +458,8 @@ def numpy_to_torch_loader(X, m, batch_size=256, shuffle=True,
         Batch size.
     shuffle : bool, default=True
         Whether to shuffle the data.
+    drop_last : bool, default=False
+        Whether to drop the last batch if it is smaller than the batch size.
     device : torch.device, default=torch.device("cpu")
         Device to use.
 
@@ -466,6 +473,7 @@ def numpy_to_torch_loader(X, m, batch_size=256, shuffle=True,
     dataset = torch.utils.data.TensorDataset(X_torch, m_torch)
     dataloader = torch.utils.data.DataLoader(dataset,
                                              batch_size=batch_size,
+                                             drop_last=drop_last,
                                              shuffle=shuffle)
     return dataloader
 

--- a/sk_cathode/generative_models/conditional_normalizing_flow_nflows.py
+++ b/sk_cathode/generative_models/conditional_normalizing_flow_nflows.py
@@ -70,6 +70,9 @@ class ConditionalNormalizingFlow(BaseEstimator):
         effect if no validation set is provided to the fit method.
     batch_size : int, default=128
         Batch size during training.
+    drop_last : bool, default=True
+        Whether to drop the last training batch if it is smaller
+        than the batch size.
     epochs : int, default=100
         Number of epochs to train for. In case early stopping is used,
         this is treated as an upper limit. Then also None can be provided,
@@ -84,8 +87,8 @@ class ConditionalNormalizingFlow(BaseEstimator):
                  num_hidden=64, num_layers=2, num_bins=8,
                  tail_bound=10, batch_norm=False, lr=0.0001,
                  weight_decay=0.000001, early_stopping=False,
-                 patience=10, no_gpu=False,
-                 val_split=0.2, batch_size=256, epochs=100, verbose=False):
+                 patience=10, no_gpu=False, val_split=0.2, batch_size=256,
+                 drop_last=True, epochs=100, verbose=False):
 
         if model_type != "MAF":
             raise NotImplementedError
@@ -104,6 +107,7 @@ class ConditionalNormalizingFlow(BaseEstimator):
         self.patience = patience
         self.val_split = val_split
         self.batch_size = batch_size
+        self.drop_last = drop_last
         self.epochs = epochs
         self.verbose = verbose
 
@@ -177,6 +181,11 @@ class ConditionalNormalizingFlow(BaseEstimator):
             "A finite number of epochs must be set if early stopping"
             " is not used!")
 
+        if self.drop_last:
+            assert X.shape[0] >= self.batch_size, (
+                "If drop_last is True, X needs to have at least as many"
+                " samples as the batch size!")
+
         # allowing not to provide validation set, just for compatibility with
         # the sklearn API
         if X_val is None and m_val is None:
@@ -207,10 +216,12 @@ class ConditionalNormalizingFlow(BaseEstimator):
         train_loader = numpy_to_torch_loader(X_train, m_train,
                                              batch_size=self.batch_size,
                                              shuffle=True,
+                                             drop_last=self.drop_last,
                                              device=self.device)
         val_loader = numpy_to_torch_loader(X_val, m_val,
                                            batch_size=self.batch_size,
                                            shuffle=True,
+                                           drop_last=False,
                                            device=self.device)
 
         # record also untrained losses
@@ -604,7 +615,7 @@ class ConditionalNormalizingFlow(BaseEstimator):
 # utility functions
 
 def numpy_to_torch_loader(X, m, batch_size=256, shuffle=True,
-                          device=torch.device("cpu")):
+                          drop_last=False, device=torch.device("cpu")):
     """Builds a torch DataLoader from numpy arrays.
 
     Parameters
@@ -617,6 +628,8 @@ def numpy_to_torch_loader(X, m, batch_size=256, shuffle=True,
         Batch size.
     shuffle : bool, default=True
         Whether to shuffle the data.
+    drop_last : bool, default=False
+        Whether to drop the last batch if it is smaller than the batch size.
     device : torch.device, default=torch.device("cpu")
         Device to use.
 
@@ -629,7 +642,7 @@ def numpy_to_torch_loader(X, m, batch_size=256, shuffle=True,
     m_torch = torch.from_numpy(m).type(torch.FloatTensor).to(device)
     dataset = torch.utils.data.TensorDataset(X_torch, m_torch)
     dataloader = torch.utils.data.DataLoader(
-        dataset, batch_size=batch_size, shuffle=shuffle)
+        dataset, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last)
     return dataloader
 
 

--- a/sk_cathode/generative_models/conditional_normalizing_flow_pyro.py
+++ b/sk_cathode/generative_models/conditional_normalizing_flow_pyro.py
@@ -80,6 +80,9 @@ class ConditionalNormalizingFlow(BaseEstimator):
         effect if no validation set is provided to the fit method.
     batch_size : int, default=128
         Batch size during training.
+    drop_last : bool, default=True
+        Whether to drop the last training batch if it is smaller
+        than the batch size.
     epochs : int, default=100
         Number of epochs to train for. In case early stopping is used,
         this is treated as an upper limit. Then also None can be provided,
@@ -96,8 +99,8 @@ class ConditionalNormalizingFlow(BaseEstimator):
                  pre_exp_tanh=False, batch_norm=True, batch_norm_momentum=0.1,
                  clips_logscale=[-3, 3], use_stable=False, lr=0.0001,
                  weight_decay=0.000001, early_stopping=False,
-                 patience=10, no_gpu=False, val_split=0.2,
-                 batch_size=256, epochs=100, verbose=False):
+                 patience=10, no_gpu=False, val_split=0.2, batch_size=256,
+                 drop_last=True, epochs=100, verbose=False):
 
         if model_type != "MAF":
             raise NotImplementedError
@@ -118,6 +121,7 @@ class ConditionalNormalizingFlow(BaseEstimator):
         self.patience = patience
         self.val_split = val_split
         self.batch_size = batch_size
+        self.drop_last = drop_last
         self.epochs = epochs
         self.verbose = verbose
 
@@ -226,6 +230,10 @@ class ConditionalNormalizingFlow(BaseEstimator):
             "A finite number of epochs must be set if early stopping"
             " is not used!")
 
+        if self.drop_last:
+            assert X.shape[0] >= self.batch_size, (
+                "If drop_last is True, X needs to have at least as many"
+                " samples as the batch size!")
         # allowing not to provide validation set, just for compatibility with
         # the sklearn API
         if X_val is None and m_val is None:
@@ -256,10 +264,12 @@ class ConditionalNormalizingFlow(BaseEstimator):
         train_loader = numpy_to_torch_loader(X_train, m_train,
                                              batch_size=self.batch_size,
                                              shuffle=True,
+                                             drop_last=self.drop_last,
                                              device=self.device)
         val_loader = numpy_to_torch_loader(X_val, m_val,
                                            batch_size=self.batch_size,
                                            shuffle=True,
+                                           drop_last=False,
                                            device=self.device)
 
         # record also untrained losses
@@ -640,7 +650,7 @@ class ConditionalNormalizingFlow(BaseEstimator):
 # utility functions
 
 def numpy_to_torch_loader(X, m, batch_size=256, shuffle=True,
-                          device=torch.device("cpu")):
+                          drop_last=False, device=torch.device("cpu")):
     """Builds a torch DataLoader from numpy arrays.
 
     Parameters
@@ -653,6 +663,8 @@ def numpy_to_torch_loader(X, m, batch_size=256, shuffle=True,
         Batch size.
     shuffle : bool, default=True
         Whether to shuffle the data.
+    drop_last : bool, default=False
+        Whether to drop the last batch if it is smaller than the batch size.
     device : torch.device, default=torch.device("cpu")
         Device to use.
 
@@ -665,7 +677,7 @@ def numpy_to_torch_loader(X, m, batch_size=256, shuffle=True,
     m_torch = torch.from_numpy(m).type(torch.FloatTensor).to(device)
     dataset = torch.utils.data.TensorDataset(X_torch, m_torch)
     dataloader = torch.utils.data.DataLoader(
-        dataset, batch_size=batch_size, shuffle=shuffle)
+        dataset, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last)
     return dataloader
 
 


### PR DESCRIPTION
Small patch that adds the options to drop the last batch from the generative model training in case it is not full. In the case where the last batch only contains few data points, they can cause instabilities during training as they get a very high effective weight. The option is set to True by default but can be turned off during model instantiation.

Spotted by @loeschet.