### PR TITLE
Fixing errors when printing models and simplifying installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+.vscode/
+
 demos/raw_data/
 demos/input_data/
 demos/input_data_deltaR/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,20 @@ The primary goal is to make these anomaly detection methods more accessible and 
 
 ## Installation
 
-Just clone via the usual way. The `requirements.txt` covers the necessary libraries to run the default demo notebook.
+Just clone via the usual way, for example:
+
+```bash
+git clone git@github.com:uhh-pd-ml/sk_cathode.git
+cd sk_cathode
+```
+
+The `requirements.txt` covers the necessary libraries to run the default demo notebook. For example, one can create a fresh conda environment and install the dependencies with:
+
+```bash
+conda create -n "sk_cathode_env" python=3.9.7
+conda activate sk_cathode_env
+pip install -r requirements.txt
+```
 
 In order to run the Normalizing Flow with Pyro backend, one further needs to install [Pyro](https://pyro.ai/). For the Conditional Flow Matching generative model, one needs to install [torchdyn](https://torchdyn.org/). The `requirements_full.txt` includes these additional dependencies.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,6 @@ mpmath==1.3.0
 munkres==1.1.4
 nest_asyncio==1.6.0
 networkx==3.2.1
-nflows==0.14
 numexpr==2.8.7
 numpy==1.26.3
 oauthlib==3.2.2

--- a/sk_cathode/classifier_models/boosted_decision_tree.py
+++ b/sk_cathode/classifier_models/boosted_decision_tree.py
@@ -57,11 +57,10 @@ class HGBClassifier(BaseEstimator):
         Whether to print progress during training.
     """
 
-    def __init__(self, *args, save_path=None, load=False,
+    def __init__(self, save_path=None, load=False,
                  max_bins=127,  early_stopping=True,
                  patience=10, max_iters=100, val_split=0.2,
-                 split_seed=None, use_class_weights=True, verbose=False,
-                 **kwargs):
+                 split_seed=None, use_class_weights=True, verbose=False):
 
         self.save_path = save_path
         if save_path is not None:
@@ -78,13 +77,10 @@ class HGBClassifier(BaseEstimator):
         self.split_seed = split_seed
         self.use_class_weights = use_class_weights
         self.verbose = verbose
-        self.args = args
-        self.kwargs = kwargs
 
         self.model = HistGradientBoostingClassifier(
-            *args, max_bins=max_bins, class_weight="balanced",
-            max_iter=1, early_stopping=False, warm_start=True,
-            **kwargs)
+            max_bins=max_bins, class_weight="balanced",
+            max_iter=1, early_stopping=False, warm_start=True)
 
         if split_seed is not None:
             self.model.split_seed = split_seed

--- a/sk_cathode/classifier_models/neural_network_classifier.py
+++ b/sk_cathode/classifier_models/neural_network_classifier.py
@@ -84,7 +84,12 @@ class NeuralNetworkClassifier(BaseEstimator):
             self.clsf_model_path = join(save_path, "CLSF_models/")
         else:
             self.clsf_model_path = None
+        self.load = load
 
+        self.n_inputs = n_inputs
+        self.layers = layers
+        self.lr = lr
+        self.no_gpu = no_gpu
         self.model = NeuralNetwork(layers, n_inputs=n_inputs)
         self.optimizer = optim.Adam(self.model.parameters(), lr=lr)
         self.loss = F.binary_cross_entropy

--- a/sk_cathode/generative_models/conditional_flow_matching.py
+++ b/sk_cathode/generative_models/conditional_flow_matching.py
@@ -72,7 +72,7 @@ class ConditionalFlowMatching(BaseEstimator):
         self,
         save_path=None,
         load=False,
-        optimizer="Adam",
+        optimizer_name="Adam",
         num_inputs=4,
         num_cond_inputs=1,
         num_blocks=1,
@@ -88,7 +88,8 @@ class ConditionalFlowMatching(BaseEstimator):
         epochs=100,
         verbose=False
     ):
-        if optimizer != "Adam":
+        self.optimizer_name = optimizer_name
+        if optimizer_name != "Adam":
             raise NotImplementedError
 
         self.save_path = save_path
@@ -96,10 +97,17 @@ class ConditionalFlowMatching(BaseEstimator):
             self.de_model_path = join(save_path, "DE_models/")
         else:
             self.de_model_path = None
+        self.load = load
 
+        self.no_gpu = no_gpu
         self.device = torch.device("cuda:0" if torch.cuda.is_available()
                                    and not no_gpu else "cpu")
         self.num_inputs = num_inputs
+        self.num_cond_inputs = num_cond_inputs
+        self.num_blocks = num_blocks
+        self.activation_function = activation_function
+        self.lr = lr
+        self.weight_decay = weight_decay
         self.early_stopping = early_stopping
         self.patience = patience
         self.val_split = val_split

--- a/sk_cathode/generative_models/conditional_normalizing_flow_nflows.py
+++ b/sk_cathode/generative_models/conditional_normalizing_flow_nflows.py
@@ -82,7 +82,7 @@ class ConditionalNormalizingFlow(BaseEstimator):
         Whether to print progress during training.
     """
     def __init__(self, save_path=None, load=False,
-                 model_type="MAF", optimizer="Adam",
+                 model_type="MAF", optimizer_name="Adam",
                  num_inputs=4, num_cond_inputs=1, num_blocks=10,
                  num_hidden=64, num_layers=2, num_bins=8,
                  tail_bound=10, batch_norm=False, lr=0.0001,
@@ -90,9 +90,11 @@ class ConditionalNormalizingFlow(BaseEstimator):
                  patience=10, no_gpu=False, val_split=0.2, batch_size=256,
                  drop_last=True, epochs=100, verbose=False):
 
+        self.model_type = model_type
+        self.optimizer_name = optimizer_name
         if model_type != "MAF":
             raise NotImplementedError
-        if optimizer != "Adam":
+        if optimizer_name != "Adam":
             raise NotImplementedError
 
         self.save_path = save_path
@@ -100,7 +102,9 @@ class ConditionalNormalizingFlow(BaseEstimator):
             self.de_model_path = join(save_path, "DE_models/")
         else:
             self.de_model_path = None
+        self.load = load
 
+        self.no_gpu = no_gpu
         self.device = torch.device("cuda:0" if torch.cuda.is_available()
                                    and not no_gpu else "cpu")
         self.early_stopping = early_stopping
@@ -110,6 +114,17 @@ class ConditionalNormalizingFlow(BaseEstimator):
         self.drop_last = drop_last
         self.epochs = epochs
         self.verbose = verbose
+
+        self.num_inputs = num_inputs
+        self.num_cond_inputs = num_cond_inputs
+        self.num_blocks = num_blocks
+        self.num_hidden = num_hidden
+        self.num_layers = num_layers
+        self.num_bins = num_bins
+        self.tail_bound = tail_bound
+        self.batch_norm = batch_norm
+        self.lr = lr
+        self.weight_decay = weight_decay
 
         # metadata routing for pipeline
         # TODO implement same for jacobians and sampling

--- a/sk_cathode/generative_models/conditional_normalizing_flow_pyro.py
+++ b/sk_cathode/generative_models/conditional_normalizing_flow_pyro.py
@@ -93,7 +93,8 @@ class ConditionalNormalizingFlow(BaseEstimator):
     """
 
     def __init__(self, save_path=None, load=False,
-                 model_type="MAF", transform="Affine", optimizer="Adam",
+                 model_type="MAF", transformation="Affine",
+                 optimizer_name="Adam",
                  num_inputs=4, num_cond_inputs=1, num_blocks=15,
                  num_hidden=128, activation_function="relu",
                  pre_exp_tanh=False, batch_norm=True, batch_norm_momentum=0.1,
@@ -102,11 +103,14 @@ class ConditionalNormalizingFlow(BaseEstimator):
                  patience=10, no_gpu=False, val_split=0.2, batch_size=256,
                  drop_last=True, epochs=100, verbose=False):
 
+        self.model_type = model_type
+        self.transformation = transformation
+        self.optimizer_name = optimizer_name
         if model_type != "MAF":
             raise NotImplementedError
-        if transform != "Affine":
+        if transformation != "Affine":
             raise NotImplementedError
-        if optimizer != "Adam":
+        if optimizer_name != "Adam":
             raise NotImplementedError
 
         self.save_path = save_path
@@ -114,7 +118,9 @@ class ConditionalNormalizingFlow(BaseEstimator):
             self.de_model_path = join(save_path, "DE_models/")
         else:
             self.de_model_path = None
+        self.load = load
 
+        self.no_gpu = no_gpu
         self.device = torch.device("cuda:0" if torch.cuda.is_available()
                                    and not no_gpu else "cpu")
         self.early_stopping = early_stopping
@@ -124,6 +130,19 @@ class ConditionalNormalizingFlow(BaseEstimator):
         self.drop_last = drop_last
         self.epochs = epochs
         self.verbose = verbose
+
+        self.num_inputs = num_inputs
+        self.num_cond_inputs = num_cond_inputs
+        self.num_blocks = num_blocks
+        self.num_hidden = num_hidden
+        self.activation_function = activation_function
+        self.pre_exp_tanh = pre_exp_tanh
+        self.batch_norm = batch_norm
+        self.batch_norm_momentum = batch_norm_momentum
+        self.clips_logscale = clips_logscale
+        self.use_stable = use_stable
+        self.lr = lr
+        self.weight_decay = weight_decay
 
         # metadata routing for pipeline
         # TODO implement same for jacobians and sampling

--- a/sk_cathode/generative_models/conditional_normalizing_flow_torch.py
+++ b/sk_cathode/generative_models/conditional_normalizing_flow_torch.py
@@ -89,7 +89,8 @@ class ConditionalNormalizingFlow(BaseEstimator):
     """
 
     def __init__(self, save_path=None, load=False,
-                 model_type="MAF", transform="Affine", optimizer="Adam",
+                 model_type="MAF", transformation="Affine",
+                 optimizer_name="Adam",
                  num_inputs=4, num_cond_inputs=1, num_blocks=15,
                  num_hidden=128, activation_function="relu",
                  pre_exp_tanh=False, batch_norm=True, batch_norm_momentum=1,
@@ -97,11 +98,14 @@ class ConditionalNormalizingFlow(BaseEstimator):
                  patience=10, no_gpu=False, val_split=0.2, batch_size=256,
                  drop_last=True, epochs=100, verbose=False):
 
+        self.model_type = model_type
+        self.transformation = transformation
+        self.optimizer_name = optimizer_name
         if model_type != "MAF":
             raise NotImplementedError
-        if transform != "Affine":
+        if transformation != "Affine":
             raise NotImplementedError
-        if optimizer != "Adam":
+        if optimizer_name != "Adam":
             raise NotImplementedError
 
         self.save_path = save_path
@@ -109,7 +113,9 @@ class ConditionalNormalizingFlow(BaseEstimator):
             self.de_model_path = join(save_path, "DE_models/")
         else:
             self.de_model_path = None
+        self.load = load
 
+        self.no_gpu = no_gpu
         self.device = torch.device("cuda:0" if torch.cuda.is_available()
                                    and not no_gpu else "cpu")
         self.early_stopping = early_stopping
@@ -119,6 +125,17 @@ class ConditionalNormalizingFlow(BaseEstimator):
         self.drop_last = drop_last
         self.epochs = epochs
         self.verbose = verbose
+
+        self.num_inputs = num_inputs
+        self.num_cond_inputs = num_cond_inputs
+        self.num_blocks = num_blocks
+        self.num_hidden = num_hidden
+        self.activation_function = activation_function
+        self.pre_exp_tanh = pre_exp_tanh
+        self.batch_norm = batch_norm
+        self.batch_norm_momentum = batch_norm_momentum
+        self.lr = lr
+        self.weight_decay = weight_decay
 
         # metadata routing for pipeline
         # TODO implement same for jacobians and sampling

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -37,3 +37,9 @@ def test_fit(classifier_model):
 def test_predict(classifier_model):
     predict_output = classifier_model.predict(X_test)
     assert predict_output.shape == (X_test.shape[0], 1)
+
+
+@pytest.mark.parametrize("classifier_model", classifier_models)
+def test_print(classifier_model):
+    print(classifier_model)
+    assert True

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -123,3 +123,9 @@ def test_score_samples(generative_model):
 def test_score(generative_model):
     score_output = generative_model.score(X_test, m_test)
     assert isinstance(score_output, float)
+
+
+@pytest.mark.parametrize("generative_model", generative_models)
+def test_print(generative_model):
+    print(generative_model)
+    assert True

--- a/tests/test_scalers.py
+++ b/tests/test_scalers.py
@@ -81,3 +81,9 @@ def test_inverse_jacobian_determinant(scaler):
     jacobian_output = scaler.inverse_jacobian_determinant(
         X_test)
     assert jacobian_output.shape == (X_test.shape[0], 1)
+
+
+@pytest.mark.parametrize("scaler", scalers)
+def test_print(scaler):
+    print(scaler)
+    assert True


### PR DESCRIPTION
Previously, there was an error when a classifier or generative model was printed because it inherits the `repr` function from the sklearn `BaseEstimator`, which needs all keyword arguments to the constructor to be saved as class attributes. This becomes visible when `model.fit()` is the last line of a jupyter notebook cell. This is now fixed and the unit tests include checking whether `print(model)`works.

Moreover, I got the feedback that the installation instructions are not that beginner friendly and the default `requirements.txt` contains the `nflows` library, which is imported in the default torch flow but not actually used. This is now removed and the install guide features example code snippets.