### PR TITLE
Adding automatic build of Docker image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'docker'
     tags:
       - '*'
     paths:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build image
-        run: docker build -f Dockerfile --tag ${CONTAINER_REGISTRY}/${IMAGE_NAME}:latest docker
+        run: docker build -f Dockerfile --tag ${CONTAINER_REGISTRY}/${IMAGE_NAME}:latest .
 
       # Login and push this image if this is on the main branch
       - name: Login to Dockerhub container registry
@@ -59,7 +59,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build image
-        run: docker build -f Dockerfile --tag ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${{  github.ref_name  }} docker
+        run: docker build -f Dockerfile --tag ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${{  github.ref_name  }} .
 
       - name: Login to Dockerhub container registry
         run: docker login -u ${{ vars.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -21,7 +21,7 @@ on:
       - 'requirements_full.txt'
 
 env:
-  CONTAINER_REGISTRY: jobirk
+  CONTAINER_REGISTRY: ${{ vars.DOCKERHUB_USERNAME }}
   IMAGE_NAME: sk_cathode
 
 jobs:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - '*'
+    # we only want to run the workflow if one of the relevant files has changed
     paths:
       - 'Dockerfile'
       - 'requirements.txt'
@@ -35,7 +36,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build image
-        run: docker build -f docker/Dockerfile --tag ${CONTAINER_REGISTRY}/${IMAGE_NAME}:latest docker
+        run: docker build -f Dockerfile --tag ${CONTAINER_REGISTRY}/${IMAGE_NAME}:latest docker
 
       # Login and push this image if this is on the main branch
       - name: Login to Dockerhub container registry
@@ -58,7 +59,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build image
-        run: docker build -f docker/Dockerfile --tag ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${{  github.ref_name  }} docker
+        run: docker build -f Dockerfile --tag ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${{  github.ref_name  }} docker
 
       - name: Login to Dockerhub container registry
         run: docker login -u ${{ vars.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,67 @@
+name: Docker build
+
+on:
+  pull_request:
+    branches:
+      - '*'
+    paths:
+      - 'Dockerfile'
+      - 'requirements.txt'
+      - 'requirements_full.txt'
+  push:
+    branches:
+      - 'main'
+      - 'docker'
+    tags:
+      - '*'
+    paths:
+      - 'Dockerfile'
+      - 'requirements.txt'
+      - 'requirements_full.txt'
+
+env:
+  CONTAINER_REGISTRY: jobirk
+  IMAGE_NAME: sk_cathode
+
+jobs:
+  build_latest:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build image
+        run: docker build -f docker/Dockerfile --tag ${CONTAINER_REGISTRY}/${IMAGE_NAME}:latest docker
+
+      # Login and push this image if this is on the main branch
+      - name: Login to Dockerhub container registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: docker login -u ${{ vars.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: docker push ${CONTAINER_REGISTRY}/${IMAGE_NAME}:latest
+
+  build_release:
+    # Build an extra image for tagged commits
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.ref, 'refs/tags')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build image
+        run: docker build -f docker/Dockerfile --tag ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${{  github.ref_name  }} docker
+
+      - name: Login to Dockerhub container registry
+        run: docker login -u ${{ vars.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push image
+        run: docker push ${CONTAINER_REGISTRY}/${IMAGE_NAME}:${{  github.ref_name  }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM python:3.9.7-slim-buster
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get update && apt-get install -y \
-    vim \
-    wget \
     curl \
     git \
+    vim \
+    wget \
     zsh
 
 WORKDIR /sk_cathode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.9.7-slim-buster
+
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get update && apt-get install -y \
+    vim \
+    wget \
+    curl \
+    git \
+    zsh
+
+WORKDIR /sk_cathode
+COPY requirements.txt .
+
+# create venv, activate it, and install requirements
+RUN apt-get update && apt-get install -y python3-venv
+RUN python3 -m venv sk_cathode_venv 
+RUN /sk_cathode/sk_cathode_venv/bin/python3 -m pip install --upgrade pip
+RUN . sk_cathode_venv/bin/activate 
+RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN apt-get update && apt-get install -y python3-venv
 RUN python3 -m venv sk_cathode_venv 
 RUN /sk_cathode/sk_cathode_venv/bin/python3 -m pip install --upgrade pip
 RUN . sk_cathode_venv/bin/activate 
-RUN pip install -r requirements.txt
+# RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,11 @@ RUN apt-get update && apt-get install -y \
     zsh
 
 WORKDIR /sk_cathode
-COPY requirements.txt .
+COPY requirements_full.txt .
 
-# create venv, activate it, and install requirements
+# create venv, activate it, and install requirements_full
 RUN apt-get update && apt-get install -y python3-venv
 RUN python3 -m venv sk_cathode_venv 
 RUN /sk_cathode/sk_cathode_venv/bin/python3 -m pip install --upgrade pip
 RUN . sk_cathode_venv/bin/activate 
-RUN pip install -r requirements.txt
+RUN pip install -r requirements_full.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN apt-get update && apt-get install -y python3-venv
 RUN python3 -m venv sk_cathode_venv 
 RUN /sk_cathode/sk_cathode_venv/bin/python3 -m pip install --upgrade pip
 RUN . sk_cathode_venv/bin/activate 
-# RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,4 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /sk_cathode
 COPY requirements_full.txt .
 
-# create venv, activate it, and install requirements_full
-RUN apt-get update && apt-get install -y python3-venv
-RUN python3 -m venv sk_cathode_venv 
-RUN /sk_cathode/sk_cathode_venv/bin/python3 -m pip install --upgrade pip
-RUN . sk_cathode_venv/bin/activate 
 RUN pip install -r requirements_full.txt

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ following command:
 singularity shell docker://jobirk/sk_cathode:latest
 ```
 
+To use the singularity container in combination with VSCode, follow the [instructions in `joschkabirk/docker-template`](https://github.com/joschkabirk/docker-template?tab=readme-ov-file#set-up-vscode-for-remote-development-with-singularity).
+
 ### Installation via conda/pip
 
 Just clone via the usual way, for example:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   - [Demos](#demos)
   - [Installation](#installation)
     - [Docker image](#docker-image)
-    - [Installation via pip](#installation-via-pip)
+    - [Installation via conda/pip](#installation-via-condapip)
   - [Shared class methods](#shared-class-methods)
     - [Generative model methods](#generative-model-methods)
     - [Classifier methods](#classifier-methods)
@@ -56,7 +56,47 @@ following command:
 singularity shell docker://jobirk/sk_cathode:latest
 ```
 
-To use the singularity container in combination with VSCode, follow the [instructions in `joschkabirk/docker-template`](https://github.com/joschkabirk/docker-template?tab=readme-ov-file#set-up-vscode-for-remote-development-with-singularity).
+General info about how to run a singularity container in combination with VSCode, can be 
+found in the [instructions in `joschkabirk/docker-template`](https://github.com/joschkabirk/docker-template?tab=readme-ov-file#set-up-vscode-for-remote-development-with-singularity).
+
+The instructions below are tested on the DESY Maxwell cluster.
+
+1. Create folders for the Singularity cache and temporary files:
+```bash
+mkdir -p /gpfs/dust/maxwell/user/$USER/.singularity/cache
+mkdir -p /gpfs/dust/maxwell/user/$USER/.singularity/tmp
+mkdir -p /gpfs/dust/maxwell/user/$USER/singularity_images
+```
+2. Tell singularity to use these folders by adding the following lines to your `~/.bashrc`/`~/.zshrc`:
+```bash
+export SINGULARITY_CACHEDIR=/gpfs/dust/maxwell/user/$USER/.singularity/cache
+export SINGULARITY_TMPDIR=/gpfs/dust/maxwell/user/$USER/.singularity/tmp
+```
+3. Pull the image from the Docker Hub and convert into a Singularity image.
+NOTE: this takes quite some time and is not required if a colleague (who works
+on the same cluster) has already done this and provides you access to their
+`.sif` file.
+```bash
+singularity build /gpfs/dust/maxwell/user/$USER/singularity_images/sk_cathode.sif docker://jobirk/sk_cathode:latest
+```
+4. Setup the VSCode connection to Maxwell. Add the following entry to your `~/.ssh/config`. This tells VSCode to start the whole remote development environment with Singularity on Maxwell.
+```
+Host sk_cathode_demo
+    RemoteCommand export SINGULARITY_CACHEDIR=<your_cachedir> && export SINGULARITY_TMPDIR=<your_tmpdir> && singularity exec --nv -B /beegfs/desy/user -B /gpfs/dust/maxwell/user <path_to_the_sif_file> /bin/zsh
+    User <your_username>
+    HostName max-display004.desy.de
+    RequestTTY yes
+```
+5. Set the install path of the corresponding VSCode container extension in the `settings.json` file (local VSCode settings):
+```json
+"remote.SSH.serverInstallPath": {
+    "sk_cathode_demo": "<some_path_where_you_have_enough_space>"
+}
+```
+6. Now connect to this host in VSCode, open your folder where you have the things you want
+to run, and install the jupyter extension (to run notebooks in VSCode):
+![](https://syncandshare.desy.de/index.php/s/m355983ZtRxFYzx/download)
+
 
 ### Installation via conda/pip
 

--- a/README.md
+++ b/README.md
@@ -56,13 +56,6 @@ following command:
 singularity shell docker://jobirk/sk_cathode:latest
 ```
 
-You can then activate the virtual environment inside the container with the 
-following command:
-
-```bash
-source /sk_cathode/sk_cathode_venv/bin/activate
-```
-
 ### Installation via conda/pip
 
 Just clone via the usual way, for example:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ following command:
 source /sk_cathode/sk_cathode_venv/bin/activate
 ```
 
-### Installation via pip
+### Installation via conda/pip
 
 Just clone via the usual way, for example:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,25 @@
 # sk_cathode
 
+**Table of Contents**
+- [sk\_cathode](#sk_cathode)
+  - [Core idea](#core-idea)
+  - [Demos](#demos)
+  - [Installation](#installation)
+    - [Docker image](#docker-image)
+    - [Installation via pip](#installation-via-pip)
+  - [Shared class methods](#shared-class-methods)
+    - [Generative model methods](#generative-model-methods)
+    - [Classifier methods](#classifier-methods)
+    - [Preprocessing scaler methods](#preprocessing-scaler-methods)
+  - [Overview of existing building blocks](#overview-of-existing-building-blocks)
+    - [Generative models](#generative-models)
+    - [Classifier models](#classifier-models)
+    - [Preprocessing and pipelines](#preprocessing-and-pipelines)
+    - [Ensembling](#ensembling)
+    - [Evaluation](#evaluation)
+  - [Contributing](#contributing)
+
+
 ## Core idea
 
 This (work-in-progress) repo aims to illustrate how to deploy anomaly detection models such as [CATHODE](https://arxiv.org/abs/2109.00546) and [LaCATHODE](https://arxiv.org/abs/2210.14924) by hiding technical implementation details behind a scikit-learn-like API.
@@ -19,6 +39,31 @@ The primary goal is to make these anomaly detection methods more accessible and 
 - `demos/autoencoder_gauss.ipynb` introduces a different paradigm for anomaly detection, namely outlier detection based on autoencoders. The working principle is illustrated on a Gaussian toy dataset.
 
 ## Installation
+
+### Docker image
+
+We provide a Docker image with all necessary dependencies installed.
+To start an interactive container **with Docker**, one can use the following
+command:
+
+```bash
+docker run -it --rm jobirk/sk_cathode:latest bash
+```
+
+To start an interactive container **with Singularity**, one can use the
+following command:
+```bash
+singularity shell docker://jobirk/sk_cathode:latest
+```
+
+You can then activate the virtual environment inside the container with the 
+following command:
+
+```bash
+source /sk_cathode/sk_cathode_venv/bin/activate
+```
+
+### Installation via pip
 
 Just clone via the usual way, for example:
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@
   - [Core idea](#core-idea)
   - [Demos](#demos)
   - [Installation](#installation)
-    - [Docker image](#docker-image)
-      - [General way to run the Docker image](#general-way-to-run-the-docker-image)
-      - [VSCode+Singularity on Maxwell](#vscodesingularity-on-maxwell)
     - [Installation via conda/pip](#installation-via-condapip)
+    - [Docker image](#docker-image)
   - [Shared class methods](#shared-class-methods)
     - [Generative model methods](#generative-model-methods)
     - [Classifier methods](#classifier-methods)
@@ -20,6 +18,8 @@
     - [Ensembling](#ensembling)
     - [Evaluation](#evaluation)
   - [Contributing](#contributing)
+  - [Appendix](#appendix)
+    - [VSCode+Singularity on Maxwell](#vscodesingularity-on-maxwell)
 
 
 ## Core idea
@@ -42,70 +42,6 @@ The primary goal is to make these anomaly detection methods more accessible and 
 
 ## Installation
 
-### Docker image
-
-We provide a Docker image with all necessary dependencies installed.
-
-#### General way to run the Docker image
-
-To start an interactive container **with Docker**, one can use the following
-command:
-
-```bash
-docker run -it --rm jobirk/sk_cathode:latest bash
-```
-
-To start an interactive container **with Singularity**, one can use the
-following command:
-```bash
-singularity shell docker://jobirk/sk_cathode:latest
-```
-NOTE: If you or one of your colleagues has already converted the Docker image to a 
-Singularity image (using `singularity build`), you can use the `.sif` file directly.
-
-#### VSCode+Singularity on Maxwell
-
-General info about how to run a singularity container in combination with VSCode, can be 
-found in the [instructions in `joschkabirk/docker-template`](https://github.com/joschkabirk/docker-template?tab=readme-ov-file#set-up-vscode-for-remote-development-with-singularity).
-
-The instructions below are tested on the DESY Maxwell cluster.
-
-1. Create folders for the Singularity cache and temporary files:
-```bash
-mkdir -p /gpfs/dust/maxwell/user/$USER/.singularity/cache
-mkdir -p /gpfs/dust/maxwell/user/$USER/.singularity/tmp
-mkdir -p /gpfs/dust/maxwell/user/$USER/singularity_images
-```
-2. Tell singularity to use these folders by adding the following lines to your `~/.bashrc`/`~/.zshrc`:
-```bash
-export SINGULARITY_CACHEDIR=/gpfs/dust/maxwell/user/$USER/.singularity/cache
-export SINGULARITY_TMPDIR=/gpfs/dust/maxwell/user/$USER/.singularity/tmp
-```
-3. Pull the image from the Docker Hub and convert into a Singularity image.
-NOTE: this takes quite some time and is not required if a colleague (who works
-on the same cluster) has already done this and provides you access to their
-`.sif` file.
-```bash
-singularity build /gpfs/dust/maxwell/user/$USER/singularity_images/sk_cathode.sif docker://jobirk/sk_cathode:latest
-```
-4. Setup the VSCode connection to Maxwell. Add the following entry to your `~/.ssh/config`. This tells VSCode to start the whole remote development environment with Singularity on Maxwell.
-```
-Host sk_cathode_demo
-    RemoteCommand export SINGULARITY_CACHEDIR=<your_cachedir> && export SINGULARITY_TMPDIR=<your_tmpdir> && singularity exec --nv -B /beegfs/desy/user -B /gpfs/dust/maxwell/user <path_to_the_sif_file> /bin/zsh
-    User <your_username>
-    HostName max-display004.desy.de
-    RequestTTY yes
-```
-5. Set the install path of the corresponding VSCode container extension in the `settings.json` file (local VSCode settings):
-```json
-"remote.SSH.serverInstallPath": {
-    "sk_cathode_demo": "<some_path_where_you_have_enough_space>"
-}
-```
-6. Now connect to this host in VSCode, open your folder where you have the things you want
-to run, and install the jupyter extension (to run notebooks in VSCode):
-![](https://syncandshare.desy.de/index.php/s/m355983ZtRxFYzx/download)
-
 
 ### Installation via conda/pip
 
@@ -125,6 +61,28 @@ pip install -r requirements.txt
 ```
 
 In order to run the Normalizing Flow with Pyro backend, one further needs to install [Pyro](https://pyro.ai/). For the Conditional Flow Matching generative model, one needs to install [torchdyn](https://torchdyn.org/). The `requirements_full.txt` includes these additional dependencies.
+
+
+### Docker image
+
+We provide a Docker image with all necessary dependencies installed.
+
+To start an interactive container **with Docker**, you can use the following
+command:
+
+```bash
+docker run -it --rm jobirk/sk_cathode:latest bash
+```
+
+To start an interactive container **with Singularity**, you can use the
+following command:
+```bash
+singularity shell docker://jobirk/sk_cathode:latest
+```
+NOTE: If you or one of your colleagues has already converted the Docker image to a 
+Singularity image (using `singularity build`), you can use corresponding
+the `.sif` file directly and replace the `docker://jobirk/sk_cathode:latest` part 
+in the command above with the path to the `.sif` file.
 
 ## Shared class methods
 
@@ -209,3 +167,50 @@ Below is a brief overview of the building blocks provided in `sk_cathode`, out o
 ## Contributing
 
 The repo is very much open for contributions via pull requests, e.g. to add more classifiers and generative models, other ways of doing anomaly detection, or just an illustrative demo notebook highlighting a particular study. For questions, feel free to contact `manuel.sommerhalder[at]uni-hamburg.de`.
+
+## Appendix
+
+### VSCode+Singularity on Maxwell
+
+This section provides a brief guide on how to set up a VSCode connection to the DESY Maxwell 
+cluster, using Singularity containers.
+Setting things up on other HPC clusters should be similar.
+
+
+1. Create folders for the Singularity cache and temporary files:
+```bash
+mkdir -p /gpfs/dust/maxwell/user/$USER/.singularity/cache
+mkdir -p /gpfs/dust/maxwell/user/$USER/.singularity/tmp
+mkdir -p /gpfs/dust/maxwell/user/$USER/singularity_images
+```
+2. Tell singularity to use these folders by adding the following lines to your `~/.bashrc`/`~/.zshrc`:
+```bash
+export SINGULARITY_CACHEDIR=/gpfs/dust/maxwell/user/$USER/.singularity/cache
+export SINGULARITY_TMPDIR=/gpfs/dust/maxwell/user/$USER/.singularity/tmp
+```
+3. Pull the image from the Docker Hub and convert into a Singularity image.
+NOTE: this takes quite some time and is not required if a colleague (who works
+on the same cluster) has already done this and provides you access to their
+`.sif` file.
+```bash
+singularity build /gpfs/dust/maxwell/user/$USER/singularity_images/sk_cathode.sif docker://jobirk/sk_cathode:latest
+```
+4. Setup the VSCode connection to Maxwell. Add the following entry to your `~/.ssh/config`. This tells VSCode to start the whole remote development environment with Singularity on Maxwell.
+```
+Host sk_cathode_demo
+    RemoteCommand export SINGULARITY_CACHEDIR=<your_cachedir> && export SINGULARITY_TMPDIR=<your_tmpdir> && singularity exec --nv -B /beegfs/desy/user -B /gpfs/dust/maxwell/user <path_to_the_sif_file> /bin/zsh
+    User <your_username>
+    HostName max-display004.desy.de
+    RequestTTY yes
+```
+5. Set the install path of the corresponding VSCode container extension in the `settings.json` file (local VSCode settings):
+```json
+"remote.SSH.serverInstallPath": {
+    "sk_cathode_demo": "<some_path_where_you_have_enough_space>"
+}
+"remote.SSH.enableRemoteCommand": true,
+```
+6. Now connect to this host in VSCode, open your folder where you have the things you want
+to run, and install the jupyter extension (to run notebooks in VSCode):
+![](https://syncandshare.desy.de/index.php/s/m355983ZtRxFYzx/download)
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
   - [Demos](#demos)
   - [Installation](#installation)
     - [Docker image](#docker-image)
+      - [General way to run the Docker image](#general-way-to-run-the-docker-image)
+      - [VSCode+Singularity on Maxwell](#vscodesingularity-on-maxwell)
     - [Installation via conda/pip](#installation-via-condapip)
   - [Shared class methods](#shared-class-methods)
     - [Generative model methods](#generative-model-methods)
@@ -43,6 +45,9 @@ The primary goal is to make these anomaly detection methods more accessible and 
 ### Docker image
 
 We provide a Docker image with all necessary dependencies installed.
+
+#### General way to run the Docker image
+
 To start an interactive container **with Docker**, one can use the following
 command:
 
@@ -55,6 +60,10 @@ following command:
 ```bash
 singularity shell docker://jobirk/sk_cathode:latest
 ```
+NOTE: If you or one of your colleagues has already converted the Docker image to a 
+Singularity image (using `singularity build`), you can use the `.sif` file directly.
+
+#### VSCode+Singularity on Maxwell
 
 General info about how to run a singularity container in combination with VSCode, can be 
 found in the [instructions in `joschkabirk/docker-template`](https://github.com/joschkabirk/docker-template?tab=readme-ov-file#set-up-vscode-for-remote-development-with-singularity).


### PR DESCRIPTION
This pull request adds a first version for the automatic build of a Docker image with the `requirements_full.txt` in there.

The setup installs the `requirements_full.txt` in the global python installation. Thus, the user has all the requirements installed by default (without activating an environment).

I think this should be a good starting point and I'll fire another pull request once this is merged (cause otherwise the CI is not running, thus we'll have to merge this to then see if the changes are doing what I expect them to do).

NOTE: what is not visible in the PR itself: I also added the variable `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` in the repository settings, which are then used in the workflow.